### PR TITLE
add DJ role creation as a basic permission

### DIFF
--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
@@ -3,6 +3,7 @@ package dev.kmfg.musicbot.core;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
+import dev.kmfg.musicbot.core.commands.intermediates.CommandsRegistry;
 import dev.kmfg.musicbot.core.listenerhandlers.SelectMenuChooseListenerHandler;
 import dev.kmfg.musicbot.core.listenerhandlers.SlashCommandListenerHandler;
 import dev.kmfg.musicbot.core.listenerhandlers.UserLeaveVoiceListenerHandler;
@@ -56,11 +57,19 @@ public class KMusicBot {
         this.discordApiBuilder = null;
         Logger.info("Bot logged into discord.");
 
+        CommandsRegistry commandsRegistry = new CommandsRegistry();
+        try{
+            commandsRegistry.registerCommands(this.discordApi);
+        }
+        catch(Exception e) {
+            Logger.error(e, "Exception occurred while registering slash commands. This is likely a breaking issue and should be reported!");
+        }
+
         // setup session manager, this must be done before setting up the CommandsListener
         this.setupSessionManager();
         Logger.info("SessionManager setup.");
         // now we can listen for the commands
-        this.setupCommandsListener();
+        this.setupCommandsListener(commandsRegistry);
         Logger.info("CommandsListener setup and listening.");
 
         // Initialize each server the bot is in to create the DJ role
@@ -142,7 +151,7 @@ public class KMusicBot {
      * This MUST be called after the discordApi and sessionManager objects are properly initialized.
      * Initializes the CommandsListener with the SessionManager, then sets it to listen for the commands.
      */
-    protected void setupCommandsListener() {
-        this.discordApi.addSlashCommandCreateListener(new SlashCommandListenerHandler(this.sessionManager));
+    protected void setupCommandsListener(CommandsRegistry commandsRegistry) {
+        this.discordApi.addSlashCommandCreateListener(new SlashCommandListenerHandler(this.sessionManager, commandsRegistry));
     }
 }

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
@@ -3,7 +3,6 @@ package dev.kmfg.musicbot.core;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
-import dev.kmfg.musicbot.core.commands.intermediates.CommandsRegistry;
 import dev.kmfg.musicbot.core.listenerhandlers.SelectMenuChooseListenerHandler;
 import dev.kmfg.musicbot.core.listenerhandlers.SlashCommandListenerHandler;
 import dev.kmfg.musicbot.core.listenerhandlers.UserLeaveVoiceListenerHandler;
@@ -57,19 +56,11 @@ public class KMusicBot {
         this.discordApiBuilder = null;
         Logger.info("Bot logged into discord.");
 
-        CommandsRegistry commandsRegistry = new CommandsRegistry();
-        try{
-            commandsRegistry.registerCommands(this.discordApi);
-        }
-        catch(Exception e) {
-            Logger.error(e, "Exception occurred while registering slash commands. This is likely a breaking issue and should be reported!");
-        }
-
         // setup session manager, this must be done before setting up the CommandsListener
         this.setupSessionManager();
         Logger.info("SessionManager setup.");
         // now we can listen for the commands
-        this.setupCommandsListener(commandsRegistry);
+        this.setupCommandsListener();
         Logger.info("CommandsListener setup and listening.");
 
         // Initialize each server the bot is in to create the DJ role
@@ -151,7 +142,7 @@ public class KMusicBot {
      * This MUST be called after the discordApi and sessionManager objects are properly initialized.
      * Initializes the CommandsListener with the SessionManager, then sets it to listen for the commands.
      */
-    protected void setupCommandsListener(CommandsRegistry commandsRegistry) {
-        this.discordApi.addSlashCommandCreateListener(new SlashCommandListenerHandler(this.sessionManager, commandsRegistry));
+    protected void setupCommandsListener() {
+        this.discordApi.addSlashCommandCreateListener(new SlashCommandListenerHandler(this.sessionManager));
     }
 }

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
@@ -16,8 +16,12 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.hibernate.SessionFactory;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
+import org.javacord.api.entity.permission.RoleBuilder;
+import org.javacord.api.entity.server.Server;
 import org.tinylog.Logger;
 import se.michaelthelin.spotify.SpotifyApi;
+
+import java.awt.*;
 
 /**
  * KMusicBot fully allows for a music bot to operate. After initializing, calling start() on the object will launch the bot.
@@ -59,6 +63,13 @@ public class KMusicBot {
         this.setupCommandsListener();
         Logger.info("CommandsListener setup and listening.");
 
+        // Initialize each server the bot is in to create the DJ role
+        for (Server server : this.discordApi.getServers())
+        {
+            if (server.getRolesByName("DJ").isEmpty())
+                this.setupServer(server);
+        }
+
         // Create all listeners
         this.setupListeners();
 
@@ -73,6 +84,19 @@ public class KMusicBot {
     protected void setupListeners() {
         this.listenForServerVoiceChannelLeaves();
         this.listenForMenuSelection();
+    }
+
+    /**
+     * Setup each server with a DJ role giving users permission to use the bot.
+     */
+    protected void setupServer(Server server) {
+        RoleBuilder roleBuilder = server.createRoleBuilder();
+
+        roleBuilder
+                .setName("DJ")
+                .setMentionable(true)
+                .setColor(Color.blue)
+                .create();
     }
 
     /**

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/KMusicBot.java
@@ -26,7 +26,7 @@ public class KMusicBot {
     private static final Dotenv dotenv = Dotenv.load();
     // if the .env file does not have MAX_RECOMMENDER_THREADS, use default value of 10, else, use the .env value
     protected static final int MAX_RECOMMENDER_THREADS = dotenv.get("MAX_RECOMMENDER_THREADS") == null ?
-            10 : Integer.parseInt(dotenv.get("MAX_RECOMMENDER_THREADS"));;
+            10 : Integer.parseInt(dotenv.get("MAX_RECOMMENDER_THREADS"));
     protected DiscordApiBuilder discordApiBuilder;
     protected DiscordApi discordApi;
     protected SessionManager sessionManager;

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/JoinServerListenerHandler.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/JoinServerListenerHandler.java
@@ -1,0 +1,40 @@
+package dev.kmfg.musicbot.core.listenerhandlers;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.permission.RoleBuilder;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.server.ServerJoinEvent;
+import org.javacord.api.listener.server.ServerJoinListener;
+
+import java.awt.*;
+
+/**
+ * Handles the initialization of a server that the bot joins.
+ */
+public class JoinServerListenerHandler implements ServerJoinListener {
+
+    public JoinServerListenerHandler(DiscordApi discordApi) {
+        // Initialize each server the bot is in to create the DJ role
+        for (Server server : discordApi.getServers())
+        {
+            if (server.getRolesByName("DJ").isEmpty())
+                this.setupServer(server);
+        }
+    }
+    public void onServerJoin(ServerJoinEvent serverJoinEvent) {
+        this.setupServer(serverJoinEvent.getServer());
+    }
+
+    /**
+     * Setup each server with a DJ role giving users permission to use the bot.
+     */
+    protected void setupServer(Server server) {
+        RoleBuilder roleBuilder = server.createRoleBuilder();
+
+        roleBuilder
+                .setName("DJ")
+                .setMentionable(true)
+                .setColor(Color.blue)
+                .create();
+    }
+}

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
@@ -66,11 +66,10 @@ public class SlashCommandListenerHandler implements SlashCommandCreateListener {
 		if (user.getRoles(event.getInteraction().getServer().get()).contains(djRole))
 			return true;
 
-		event.getInteraction().createImmediateResponder().respond().thenAccept(action -> {
-			action.addEmbed(new EmbedBuilder()
+		event.getInteraction().createImmediateResponder().respond().thenAccept(action -> action.addEmbed(new EmbedBuilder()
+					.setColor(Color.red)
 					.addField("Permission denied", "You must have the " + djRole.getMentionTag() + " role I created", false))
-					.update();
-		});
+				.update());
 
 		return false;
 	}

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
@@ -66,10 +66,11 @@ public class SlashCommandListenerHandler implements SlashCommandCreateListener {
 		if (user.getRoles(event.getInteraction().getServer().get()).contains(djRole))
 			return true;
 
-		event.getInteraction().createImmediateResponder().respond().thenAccept(action -> action.addEmbed(new EmbedBuilder()
-					.setColor(Color.red)
+		event.getInteraction().createImmediateResponder().respond().thenAccept(action -> {
+			action.addEmbed(new EmbedBuilder()
 					.addField("Permission denied", "You must have the " + djRole.getMentionTag() + " role I created", false))
-				.update());
+					.update();
+		});
 
 		return false;
 	}

--- a/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
+++ b/kmusicbot-core/src/main/java/dev/kmfg/musicbot/core/listenerhandlers/SlashCommandListenerHandler.java
@@ -66,9 +66,11 @@ public class SlashCommandListenerHandler implements SlashCommandCreateListener {
 		if (user.getRoles(event.getInteraction().getServer().get()).contains(djRole))
 			return true;
 
-		event.getInteraction().getChannel().get().sendMessage(new EmbedBuilder()
-				.setColor(Color.red)
-				.addField("Permission denied", "You must have the " + djRole.getMentionTag() + " role I created", false));
+		event.getInteraction().createImmediateResponder().respond().thenAccept(action -> {
+			action.addEmbed(new EmbedBuilder()
+					.addField("Permission denied", "You must have the " + djRole.getMentionTag() + " role I created", false))
+					.update();
+		});
 
 		return false;
 	}


### PR DESCRIPTION
This change resolves issue #60 by creating a DJ role in each of the servers the bot is present in.

To interact with the bot, a user must have this role the bot creates. 