### PR TITLE
fix: null result for KMusicSong saveOrGet

### DIFF
--- a/kmusicbot-database/src/main/java/dev/kmfg/musicbot/database/repositories/KMusicSongRepo.java
+++ b/kmusicbot-database/src/main/java/dev/kmfg/musicbot/database/repositories/KMusicSongRepo.java
@@ -18,7 +18,7 @@ public class KMusicSongRepo {
 	}
 
 	public KMusicSong saveOrGet(KMusicSong kmusicSong) {
-		return this.findById(kmusicSong.getId()).orElseGet(() -> {
+		return this.findByYoutubeUrl(kmusicSong.getYoutubeUrl()).orElseGet(() -> {
             return this.save(kmusicSong).get();
         });
 	}


### PR DESCRIPTION
Previous impl would use ID for saveOrGet. While it's important to have a findById method, this is not right for saveOrGet. We should instead use findByYoutubeUrl as it is highly unlikely the saveOrGet user will pass a null youtube url, and more likely they will pass a 0 ID for the KMusicSong.